### PR TITLE
feat: expose frameWidth and frameHeight with the hook

### DIFF
--- a/src/hook.tsx
+++ b/src/hook.tsx
@@ -12,14 +12,18 @@ import {
 export function useScanBarcodes(
   types: BarcodeFormat[],
   options?: CodeScannerOptions
-): [(frame: Frame) => void, Barcode[]] {
+): [(frame: Frame) => void, Barcode[], number, number] {
   const [barcodes, setBarcodes] = useState<Barcode[]>([]);
+  const [frameWidth, setFrameWidth] = useState<number>(1);
+  const [frameHeight, setFrameHeight] = useState<number>(1);
 
   const frameProcessor = useFrameProcessor((frame) => {
     'worklet';
     const detectedBarcodes = scanBarcodes(frame, types, options);
     runOnJS(setBarcodes)(detectedBarcodes);
+    runOnJS(setFrameWidth)(frame.width);
+    runOnJS(setFrameHeight)(frame.height);
   }, []);
 
-  return [frameProcessor, barcodes];
+  return [frameProcessor, barcodes, frameWidth, frameHeight];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7393,10 +7393,10 @@ react-native-screens@^3.4.0:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
 
-react-native-vision-camera@^2.9.4:
-  version "2.9.4"
-  resolved "https://registry.yarnpkg.com/react-native-vision-camera/-/react-native-vision-camera-2.9.4.tgz#e80f9da924dbd308478a15a421957dff146b9259"
-  integrity sha512-glaemA2MHW3Yq7kM7Ty+4jPnyncDp8Opm7nH93GGoZwYOXCbTj/GzLl8yOi9NrhFE+yrq2SD4ijyxNMO2fJ7kQ==
+react-native-vision-camera@^2.13.1:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/react-native-vision-camera/-/react-native-vision-camera-2.14.1.tgz#6b9fecd5c5976167b8e8752455be24cd12c3d84f"
+  integrity sha512-zs8HAuD3pL+T/ngaDUxbvhoqR90b85ab3nm4tO4OCSBDUFhzgDoDXDm+BDhsyQaF0p05Kaskf+rkqCVBI0WEgg==
 
 react-native@0.65.1:
   version "0.65.1"


### PR DESCRIPTION
Usage:

```
const [frameProcessor, barcodes, frameWidth, frameHeight] = useScanBarcodes([BarcodeFormat.ALL_FORMATS])
```